### PR TITLE
feat: Phase 2 — multifactor.py (DOE/multi-factor plots)

### DIFF
--- a/src/drippy/__init__.py
+++ b/src/drippy/__init__.py
@@ -8,6 +8,10 @@ from drippy.onefactor import mean_plot
 from drippy.onefactor import qq_plot
 from drippy.onefactor import scatter_plot
 from drippy.onefactor import sd_plot
+from drippy.multifactor import contour_plot
+from drippy.multifactor import doe_mean_plot
+from drippy.multifactor import doe_scatter_plot
+from drippy.multifactor import doe_sd_plot
 from drippy.timeseries import autocorrelation_plot
 from drippy.timeseries import complex_demodulation_amplitude_plot
 from drippy.timeseries import complex_demodulation_phase_plot
@@ -38,8 +42,12 @@ __all__ = [
     "box_cox_linearity_plot",
     "box_cox_normality_plot",
     "box_plot",
+    "contour_plot",
     "complex_demodulation_amplitude_plot",
     "complex_demodulation_phase_plot",
+    "doe_mean_plot",
+    "doe_scatter_plot",
+    "doe_sd_plot",
     "four_plot",
     "histogram",
     "lag_plot",

--- a/src/drippy/__init__.py
+++ b/src/drippy/__init__.py
@@ -2,16 +2,16 @@
 
 import logging
 from drippy.data import EDAData
+from drippy.multifactor import contour_plot
+from drippy.multifactor import doe_mean_plot
+from drippy.multifactor import doe_scatter_plot
+from drippy.multifactor import doe_sd_plot
 from drippy.onefactor import bihistogram
 from drippy.onefactor import box_plot
 from drippy.onefactor import mean_plot
 from drippy.onefactor import qq_plot
 from drippy.onefactor import scatter_plot
 from drippy.onefactor import sd_plot
-from drippy.multifactor import contour_plot
-from drippy.multifactor import doe_mean_plot
-from drippy.multifactor import doe_scatter_plot
-from drippy.multifactor import doe_sd_plot
 from drippy.timeseries import autocorrelation_plot
 from drippy.timeseries import complex_demodulation_amplitude_plot
 from drippy.timeseries import complex_demodulation_phase_plot
@@ -42,9 +42,9 @@ __all__ = [
     "box_cox_linearity_plot",
     "box_cox_normality_plot",
     "box_plot",
-    "contour_plot",
     "complex_demodulation_amplitude_plot",
     "complex_demodulation_phase_plot",
+    "contour_plot",
     "doe_mean_plot",
     "doe_scatter_plot",
     "doe_sd_plot",

--- a/src/drippy/multifactor.py
+++ b/src/drippy/multifactor.py
@@ -1,0 +1,202 @@
+"""Plotting functions for multi-factor/DOE models."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import matplotlib.pyplot as plt
+import numpy as np
+from drippy.utilities import get_figure_and_axes
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from drippy.data import EDAData
+
+
+def doe_scatter_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    axes: np.ndarray | None = None,
+) -> tuple[Figure, np.ndarray]:
+    """Creates scatter plots of y vs each factor.
+
+    One subplot per factor in data.factors.
+
+    Args:
+        data: EDAData container. Requires factors.
+        fig: Matplotlib figure. If None, creates new figure.
+        axes: 1-D array of Axes, one per factor. If None,
+            creates new axes.
+
+    Returns:
+        (fig, axes) where axes is a 1-D array of Axes.
+    """
+    if data.factors is None:
+        msg = "doe_scatter_plot requires factors"
+        raise ValueError(msg)
+    n = len(data.factors)
+    if fig is None and axes is None:
+        fig, axes = plt.subplots(1, n)
+        axes = np.atleast_1d(axes)
+    elif axes is None:
+        axes = np.atleast_1d(fig.subplots(1, n))
+    elif fig is None:
+        axes = np.atleast_1d(axes)
+        fig = axes.flat[0].get_figure()
+    axes = np.asarray(axes)
+    if axes.shape != (n,):
+        msg = f"axes must have shape ({n},)"
+        raise ValueError(msg)
+    for ax, (name, factor) in zip(axes, data.factors.items(), strict=False):
+        ax.scatter(factor, data.y)
+        ax.set_xlabel(name)
+        ax.set_ylabel("Y")
+        ax.set_title(f"Scatter Plot: {name}")
+    fig.tight_layout()
+    return fig, axes
+
+
+def doe_mean_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    axes: np.ndarray | None = None,
+) -> tuple[Figure, np.ndarray]:
+    """Creates mean plots of y grouped by each factor's levels.
+
+    Shows group means connected by a line and a horizontal grand-mean
+    reference line for each factor.
+
+    Args:
+        data: EDAData container. Requires factors.
+        fig: Matplotlib figure. If None, creates new figure.
+        axes: 1-D array of Axes, one per factor. If None,
+            creates new axes.
+
+    Returns:
+        (fig, axes) where axes is a 1-D array of Axes.
+    """
+    if data.factors is None:
+        msg = "doe_mean_plot requires factors"
+        raise ValueError(msg)
+    n = len(data.factors)
+    if fig is None and axes is None:
+        fig, axes = plt.subplots(1, n)
+        axes = np.atleast_1d(axes)
+    elif axes is None:
+        axes = np.atleast_1d(fig.subplots(1, n))
+    elif fig is None:
+        axes = np.atleast_1d(axes)
+        fig = axes.flat[0].get_figure()
+    axes = np.asarray(axes)
+    if axes.shape != (n,):
+        msg = f"axes must have shape ({n},)"
+        raise ValueError(msg)
+    grand_mean = data.y.mean()
+    for ax, (name, factor) in zip(axes, data.factors.items(), strict=False):
+        levels = np.unique(factor)
+        means = [data.y[factor == lvl].mean() for lvl in levels]
+        ax.plot(levels, means, "o-")
+        ax.axhline(
+            grand_mean, color="r", linestyle="--", label="Grand mean"
+        )
+        ax.set_xlabel(name)
+        ax.set_ylabel("Mean of Y")
+        ax.set_title(f"Mean Plot: {name}")
+        ax.legend()
+    fig.tight_layout()
+    return fig, axes
+
+
+def doe_sd_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    axes: np.ndarray | None = None,
+) -> tuple[Figure, np.ndarray]:
+    """Creates standard deviation plots of y by each factor's levels.
+
+    Shows group standard deviations connected by a line and a horizontal
+    overall-SD reference line for each factor.
+
+    Args:
+        data: EDAData container. Requires factors.
+        fig: Matplotlib figure. If None, creates new figure.
+        axes: 1-D array of Axes, one per factor. If None,
+            creates new axes.
+
+    Returns:
+        (fig, axes) where axes is a 1-D array of Axes.
+    """
+    if data.factors is None:
+        msg = "doe_sd_plot requires factors"
+        raise ValueError(msg)
+    n = len(data.factors)
+    if fig is None and axes is None:
+        fig, axes = plt.subplots(1, n)
+        axes = np.atleast_1d(axes)
+    elif axes is None:
+        axes = np.atleast_1d(fig.subplots(1, n))
+    elif fig is None:
+        axes = np.atleast_1d(axes)
+        fig = axes.flat[0].get_figure()
+    axes = np.asarray(axes)
+    if axes.shape != (n,):
+        msg = f"axes must have shape ({n},)"
+        raise ValueError(msg)
+    overall_sd = data.y.std()
+    for ax, (name, factor) in zip(axes, data.factors.items(), strict=False):
+        levels = np.unique(factor)
+        sds = [data.y[factor == lvl].std() for lvl in levels]
+        ax.plot(levels, sds, "o-")
+        ax.axhline(
+            overall_sd, color="r", linestyle="--", label="Overall SD"
+        )
+        ax.set_xlabel(name)
+        ax.set_ylabel("Standard Deviation of Y")
+        ax.set_title(f"SD Plot: {name}")
+        ax.legend()
+    fig.tight_layout()
+    return fig, axes
+
+
+def contour_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+    doe: bool = False,
+) -> tuple[Figure, Axes]:
+    """Creates a contour plot of y over the 2D factor space.
+
+    Uses tricontourf for robustness with irregular/DOE grids.
+
+    Args:
+        data: EDAData container. Requires exactly 2 factors.
+        fig: Matplotlib figure. If None, creates new figure.
+        ax: Matplotlib axes. If None, creates new axes.
+        doe: If True, overlays design point markers.
+
+    Returns:
+        The figure and axes containing the plot.
+    """
+    if data.factors is None:
+        msg = "contour_plot requires factors"
+        raise ValueError(msg)
+    if len(data.factors) != 2:  # noqa: PLR2004
+        n_factors = len(data.factors)
+        msg = (
+            "contour_plot requires exactly 2 factors, "
+            f"got {n_factors}"
+        )
+        raise ValueError(msg)
+    fig, ax = get_figure_and_axes(fig, ax)
+    names = list(data.factors.keys())
+    f1 = data.factors[names[0]]
+    f2 = data.factors[names[1]]
+    cf = ax.tricontourf(f1, f2, data.y)
+    fig.colorbar(cf, ax=ax, label="Y")
+    if doe:
+        ax.scatter(f1, f2, color="k", marker="x", label="Design points")
+        ax.legend()
+    ax.set_xlabel(names[0])
+    ax.set_ylabel(names[1])
+    ax.set_title("Contour Plot")
+    fig.tight_layout()
+    return fig, ax

--- a/src/drippy/multifactor.py
+++ b/src/drippy/multifactor.py
@@ -95,9 +95,7 @@ def doe_mean_plot(
         levels = np.unique(factor)
         means = [data.y[factor == lvl].mean() for lvl in levels]
         ax.plot(levels, means, "o-")
-        ax.axhline(
-            grand_mean, color="r", linestyle="--", label="Grand mean"
-        )
+        ax.axhline(grand_mean, color="r", linestyle="--", label="Grand mean")
         ax.set_xlabel(name)
         ax.set_ylabel("Mean of Y")
         ax.set_title(f"Mean Plot: {name}")
@@ -146,9 +144,7 @@ def doe_sd_plot(
         levels = np.unique(factor)
         sds = [data.y[factor == lvl].std() for lvl in levels]
         ax.plot(levels, sds, "o-")
-        ax.axhline(
-            overall_sd, color="r", linestyle="--", label="Overall SD"
-        )
+        ax.axhline(overall_sd, color="r", linestyle="--", label="Overall SD")
         ax.set_xlabel(name)
         ax.set_ylabel("Standard Deviation of Y")
         ax.set_title(f"SD Plot: {name}")
@@ -181,10 +177,7 @@ def contour_plot(
         raise ValueError(msg)
     if len(data.factors) != 2:  # noqa: PLR2004
         n_factors = len(data.factors)
-        msg = (
-            "contour_plot requires exactly 2 factors, "
-            f"got {n_factors}"
-        )
+        msg = f"contour_plot requires exactly 2 factors, got {n_factors}"
         raise ValueError(msg)
     fig, ax = get_figure_and_axes(fig, ax)
     names = list(data.factors.keys())

--- a/src/drippy/multifactor.py
+++ b/src/drippy/multifactor.py
@@ -12,6 +12,27 @@ if TYPE_CHECKING:
     from drippy.data import EDAData
 
 
+def _get_figure_and_multi_axes(
+    fig: Figure | None,
+    axes: np.ndarray | None,
+    n: int,
+) -> tuple[Figure, np.ndarray]:
+    if fig is None and axes is None:
+        fig, axes = plt.subplots(1, n)
+        axes = np.atleast_1d(axes)
+    elif axes is None:
+        axes = np.atleast_1d(fig.subplots(1, n))
+    elif fig is None:
+        axes = np.atleast_1d(axes)
+        fig = axes.flat[0].get_figure()
+    else:
+        axes = np.atleast_1d(axes)
+        if axes.flat[0].figure is not fig:
+            msg = "Provided axes do not belong to provided fig."
+            raise ValueError(msg)
+    return fig, np.asarray(axes)
+
+
 def doe_scatter_plot(
     data: EDAData,
     fig: Figure | None = None,
@@ -30,19 +51,11 @@ def doe_scatter_plot(
     Returns:
         (fig, axes) where axes is a 1-D array of Axes.
     """
-    if data.factors is None:
+    if not data.factors:
         msg = "doe_scatter_plot requires factors"
         raise ValueError(msg)
     n = len(data.factors)
-    if fig is None and axes is None:
-        fig, axes = plt.subplots(1, n)
-        axes = np.atleast_1d(axes)
-    elif axes is None:
-        axes = np.atleast_1d(fig.subplots(1, n))
-    elif fig is None:
-        axes = np.atleast_1d(axes)
-        fig = axes.flat[0].get_figure()
-    axes = np.asarray(axes)
+    fig, axes = _get_figure_and_multi_axes(fig, axes, n)
     if axes.shape != (n,):
         msg = f"axes must have shape ({n},)"
         raise ValueError(msg)
@@ -74,19 +87,11 @@ def doe_mean_plot(
     Returns:
         (fig, axes) where axes is a 1-D array of Axes.
     """
-    if data.factors is None:
+    if not data.factors:
         msg = "doe_mean_plot requires factors"
         raise ValueError(msg)
     n = len(data.factors)
-    if fig is None and axes is None:
-        fig, axes = plt.subplots(1, n)
-        axes = np.atleast_1d(axes)
-    elif axes is None:
-        axes = np.atleast_1d(fig.subplots(1, n))
-    elif fig is None:
-        axes = np.atleast_1d(axes)
-        fig = axes.flat[0].get_figure()
-    axes = np.asarray(axes)
+    fig, axes = _get_figure_and_multi_axes(fig, axes, n)
     if axes.shape != (n,):
         msg = f"axes must have shape ({n},)"
         raise ValueError(msg)
@@ -123,19 +128,11 @@ def doe_sd_plot(
     Returns:
         (fig, axes) where axes is a 1-D array of Axes.
     """
-    if data.factors is None:
+    if not data.factors:
         msg = "doe_sd_plot requires factors"
         raise ValueError(msg)
     n = len(data.factors)
-    if fig is None and axes is None:
-        fig, axes = plt.subplots(1, n)
-        axes = np.atleast_1d(axes)
-    elif axes is None:
-        axes = np.atleast_1d(fig.subplots(1, n))
-    elif fig is None:
-        axes = np.atleast_1d(axes)
-        fig = axes.flat[0].get_figure()
-    axes = np.asarray(axes)
+    fig, axes = _get_figure_and_multi_axes(fig, axes, n)
     if axes.shape != (n,):
         msg = f"axes must have shape ({n},)"
         raise ValueError(msg)
@@ -172,7 +169,7 @@ def contour_plot(
     Returns:
         The figure and axes containing the plot.
     """
-    if data.factors is None:
+    if not data.factors:
         msg = "contour_plot requires factors"
         raise ValueError(msg)
     if len(data.factors) != 2:  # noqa: PLR2004

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -237,7 +237,7 @@ class TestFluentMethods:
         _, ax = univariate_data.histogram(bins=5)
         assert len(ax.patches) == 5
 
-    def test_future_module_raises_import_error(self, univariate_data):
-        """Phase 2+ methods raise ImportError until those modules exist."""
-        with pytest.raises((ImportError, ModuleNotFoundError)):
-            univariate_data.doe_scatter_plot()
+    def test_doe_scatter_plot(self, multifactor_data):
+        fig, axes = multifactor_data.doe_scatter_plot()
+        assert isinstance(fig, Figure)
+        assert isinstance(axes, np.ndarray)

--- a/tests/test_multifactor.py
+++ b/tests/test_multifactor.py
@@ -1,0 +1,163 @@
+"""Tests for the drippy.multifactor module."""
+
+from __future__ import annotations
+import matplotlib as mpl
+
+mpl.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+import drippy.multifactor as mf
+from drippy.data import EDAData
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def multifactor_data():
+    rng = np.random.default_rng(42)
+    a = np.tile([-1.0, 1.0], 4)
+    b = np.tile(np.repeat([-1.0, 1.0], 2), 2)
+    c = np.repeat([-1.0, 1.0], 4)
+    y = 2.0 * a + 1.5 * b - 0.5 * c + rng.normal(scale=0.1, size=8)
+    return EDAData(y, factors={"A": a, "B": b, "C": c})
+
+
+@pytest.fixture
+def two_factor_data():
+    rng = np.random.default_rng(42)
+    a = np.tile([-1.0, 1.0], 4)
+    b = np.repeat([-1.0, 1.0], 4)
+    y = a + b + rng.normal(scale=0.1, size=8)
+    return EDAData(y, factors={"A": a, "B": b})
+
+
+@pytest.fixture
+def no_factors_data():
+    return EDAData(np.random.default_rng(42).normal(size=8))
+
+
+class TestDoeScatterPlot:
+    def test_returns_figure_and_array(self, multifactor_data):
+        fig, axes = mf.doe_scatter_plot(multifactor_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(axes, np.ndarray)
+        assert axes.shape == (3,)
+
+    def test_requires_factors(self, no_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_scatter_plot(no_factors_data)
+
+    def test_custom_fig_axes(self, multifactor_data):
+        fig_in, axes_in = plt.subplots(1, 3)
+        fig_out, axes_out = mf.doe_scatter_plot(
+            multifactor_data, fig=fig_in, axes=axes_in
+        )
+        assert fig_out is fig_in
+        assert axes_out is axes_in
+
+    def test_one_subplot_per_factor(self, multifactor_data):
+        _, axes = mf.doe_scatter_plot(multifactor_data)
+        assert len(axes) == len(multifactor_data.factors)
+
+    def test_axes_shape_validation(self, multifactor_data):
+        fig, wrong_axes = plt.subplots(1, 2)
+        with pytest.raises(ValueError, match=r"axes must have shape"):
+            mf.doe_scatter_plot(multifactor_data, fig=fig, axes=wrong_axes)
+
+
+class TestDoeMeanPlot:
+    def test_returns_figure_and_array(self, multifactor_data):
+        fig, axes = mf.doe_mean_plot(multifactor_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(axes, np.ndarray)
+        assert axes.shape == (3,)
+
+    def test_requires_factors(self, no_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_mean_plot(no_factors_data)
+
+    def test_custom_fig_axes(self, multifactor_data):
+        fig_in, axes_in = plt.subplots(1, 3)
+        fig_out, axes_out = mf.doe_mean_plot(
+            multifactor_data, fig=fig_in, axes=axes_in
+        )
+        assert fig_out is fig_in
+        assert axes_out is axes_in
+
+    def test_each_subplot_has_grand_mean_line(self, multifactor_data):
+        _, axes = mf.doe_mean_plot(multifactor_data)
+        for ax in axes:
+            assert len(ax.get_lines()) >= 2
+
+    def test_axes_shape_validation(self, multifactor_data):
+        fig, wrong_axes = plt.subplots(1, 2)
+        with pytest.raises(ValueError, match=r"axes must have shape"):
+            mf.doe_mean_plot(multifactor_data, fig=fig, axes=wrong_axes)
+
+
+class TestDoeSdPlot:
+    def test_returns_figure_and_array(self, multifactor_data):
+        fig, axes = mf.doe_sd_plot(multifactor_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(axes, np.ndarray)
+        assert axes.shape == (3,)
+
+    def test_requires_factors(self, no_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_sd_plot(no_factors_data)
+
+    def test_custom_fig_axes(self, multifactor_data):
+        fig_in, axes_in = plt.subplots(1, 3)
+        fig_out, axes_out = mf.doe_sd_plot(
+            multifactor_data, fig=fig_in, axes=axes_in
+        )
+        assert fig_out is fig_in
+        assert axes_out is axes_in
+
+    def test_each_subplot_has_overall_sd_line(self, multifactor_data):
+        _, axes = mf.doe_sd_plot(multifactor_data)
+        for ax in axes:
+            assert len(ax.get_lines()) >= 2
+
+    def test_axes_shape_validation(self, multifactor_data):
+        fig, wrong_axes = plt.subplots(1, 2)
+        with pytest.raises(ValueError, match=r"axes must have shape"):
+            mf.doe_sd_plot(multifactor_data, fig=fig, axes=wrong_axes)
+
+
+class TestContourPlot:
+    def test_returns_figure_and_axes(self, two_factor_data):
+        fig, ax = mf.contour_plot(two_factor_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_requires_factors(self, no_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.contour_plot(no_factors_data)
+
+    def test_requires_exactly_two_factors(self, multifactor_data):
+        with pytest.raises(ValueError, match="exactly 2 factors"):
+            mf.contour_plot(multifactor_data)
+
+    def test_custom_fig_ax(self, two_factor_data):
+        fig_in, ax_in = plt.subplots()
+        fig_out, ax_out = mf.contour_plot(
+            two_factor_data, fig=fig_in, ax=ax_in
+        )
+        assert fig_out is fig_in
+        assert ax_out is ax_in
+
+    def test_doe_variant_adds_scatter_markers(self, two_factor_data):
+        _, ax_base = mf.contour_plot(two_factor_data, doe=False)
+        n_base = len(ax_base.collections)
+        plt.close("all")
+        _, ax_doe = mf.contour_plot(two_factor_data, doe=True)
+        assert len(ax_doe.collections) > n_base

--- a/tests/test_multifactor.py
+++ b/tests/test_multifactor.py
@@ -44,6 +44,11 @@ def no_factors_data():
     return EDAData(np.random.default_rng(42).normal(size=8))
 
 
+@pytest.fixture
+def empty_factors_data():
+    return EDAData(np.random.default_rng(42).normal(size=8), factors={})
+
+
 class TestDoeScatterPlot:
     def test_returns_figure_and_array(self, multifactor_data):
         fig, axes = mf.doe_scatter_plot(multifactor_data)
@@ -66,6 +71,16 @@ class TestDoeScatterPlot:
     def test_one_subplot_per_factor(self, multifactor_data):
         _, axes = mf.doe_scatter_plot(multifactor_data)
         assert len(axes) == len(multifactor_data.factors)
+
+    def test_rejects_empty_factors(self, empty_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_scatter_plot(empty_factors_data)
+
+    def test_rejects_mismatched_fig_axes(self, multifactor_data):
+        _, axes1 = plt.subplots(1, 3)
+        fig2 = plt.figure()
+        with pytest.raises(ValueError, match="do not belong"):
+            mf.doe_scatter_plot(multifactor_data, fig=fig2, axes=axes1)
 
     def test_axes_shape_validation(self, multifactor_data):
         fig, wrong_axes = plt.subplots(1, 2)
@@ -97,6 +112,16 @@ class TestDoeMeanPlot:
         for ax in axes:
             assert len(ax.get_lines()) >= 2
 
+    def test_rejects_empty_factors(self, empty_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_mean_plot(empty_factors_data)
+
+    def test_rejects_mismatched_fig_axes(self, multifactor_data):
+        _, axes1 = plt.subplots(1, 3)
+        fig2 = plt.figure()
+        with pytest.raises(ValueError, match="do not belong"):
+            mf.doe_mean_plot(multifactor_data, fig=fig2, axes=axes1)
+
     def test_axes_shape_validation(self, multifactor_data):
         fig, wrong_axes = plt.subplots(1, 2)
         with pytest.raises(ValueError, match=r"axes must have shape"):
@@ -127,6 +152,16 @@ class TestDoeSdPlot:
         for ax in axes:
             assert len(ax.get_lines()) >= 2
 
+    def test_rejects_empty_factors(self, empty_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.doe_sd_plot(empty_factors_data)
+
+    def test_rejects_mismatched_fig_axes(self, multifactor_data):
+        _, axes1 = plt.subplots(1, 3)
+        fig2 = plt.figure()
+        with pytest.raises(ValueError, match="do not belong"):
+            mf.doe_sd_plot(multifactor_data, fig=fig2, axes=axes1)
+
     def test_axes_shape_validation(self, multifactor_data):
         fig, wrong_axes = plt.subplots(1, 2)
         with pytest.raises(ValueError, match=r"axes must have shape"):
@@ -142,6 +177,10 @@ class TestContourPlot:
     def test_requires_factors(self, no_factors_data):
         with pytest.raises(ValueError, match="requires factors"):
             mf.contour_plot(no_factors_data)
+
+    def test_rejects_empty_factors(self, empty_factors_data):
+        with pytest.raises(ValueError, match="requires factors"):
+            mf.contour_plot(empty_factors_data)
 
     def test_requires_exactly_two_factors(self, multifactor_data):
         with pytest.raises(ValueError, match="exactly 2 factors"):


### PR DESCRIPTION
## Summary

- Adds `src/drippy/multifactor.py` with 4 NIST EDA functions for multi-factor/DOE models
- `doe_scatter_plot` (1.3.3.11) — one scatter subplot per factor
- `doe_mean_plot` (1.3.3.12) — group means per factor with grand-mean reference line
- `doe_sd_plot` (1.3.3.13) — group SDs per factor with overall-SD reference line
- `contour_plot` (1.3.3.10) — 2D contour via `tricontourf`, optional `doe=True` design-point overlay
- Updates `__init__.py` to export all 4 functions
- Adds `tests/test_multifactor.py` (20 tests, 4 classes, all passing)
- Updates stale `test_future_module_raises_import_error` in `test_data.py` to a live fluent-API test

## Test plan

- [ ] `uv run pytest tests/test_multifactor.py -v` — 20 new tests pass
- [ ] `uv run pytest -v` — full suite 161/161 pass
- [ ] `uv run ruff check src/drippy/multifactor.py tests/test_multifactor.py` — no errors

https://claude.ai/code/session_01CPEA56WPaLM6yN5vUshjJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPEA56WPaLM6yN5vUshjJn)_