### PR TITLE
fix: address SonarCloud S1192/S8495 issues

### DIFF
--- a/src/drippy/data.py
+++ b/src/drippy/data.py
@@ -59,7 +59,7 @@ class EDAData:
 
     def normal_probability_plot(
         self, **kwargs: Any
-    ) -> tuple[Figure, Axes] | tuple[Figure, Axes, float]:
+    ) -> tuple[Figure, Axes, float | None]:
         """Delegates to drippy.univariate.normal_probability_plot."""
         from drippy.univariate import normal_probability_plot as fn
 

--- a/src/drippy/onefactor.py
+++ b/src/drippy/onefactor.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from drippy.data import EDAData
 
+_FACTOR_LEVEL = "Factor Level"
+
 
 def scatter_plot(
     data: EDAData,
@@ -63,7 +65,7 @@ def box_plot(
     levels = np.unique(data.x)
     groups = [data.y[data.x == level] for level in levels]
     ax.boxplot(groups, tick_labels=levels)
-    ax.set_xlabel("Factor Level")
+    ax.set_xlabel(_FACTOR_LEVEL)
     ax.set_ylabel("Y")
     ax.set_title("Box Plot")
     fig.tight_layout()
@@ -185,7 +187,7 @@ def mean_plot(
     means = [data.y[data.x == level].mean() for level in levels]
     ax.plot(levels, means, "o-")
     ax.axhline(data.y.mean(), color="r", linestyle="--", label="Grand mean")
-    ax.set_xlabel("Factor Level")
+    ax.set_xlabel(_FACTOR_LEVEL)
     ax.set_ylabel("Mean of Y")
     ax.set_title("Mean Plot")
     ax.legend()
@@ -219,7 +221,7 @@ def sd_plot(
     sds = [data.y[data.x == level].std() for level in levels]
     ax.plot(levels, sds, "o-")
     ax.axhline(data.y.std(), color="r", linestyle="--", label="Overall SD")
-    ax.set_xlabel("Factor Level")
+    ax.set_xlabel(_FACTOR_LEVEL)
     ax.set_ylabel("Standard Deviation of Y")
     ax.set_title("Standard Deviation Plot")
     ax.legend()

--- a/src/drippy/univariate.py
+++ b/src/drippy/univariate.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from drippy.data import EDAData
 
+_ORDERED_VALUES = "Ordered Values"
+
 
 def run_sequence_plot(
     data: EDAData,
@@ -115,29 +117,29 @@ def normal_probability_plot(
     ax: Axes | None = None,
     *,
     return_rsquared: bool = False,
-) -> tuple[Figure, Axes] | tuple[Figure, Axes, float]:
+) -> tuple[Figure, Axes, float | None]:
     """Creates a normal probability plot.
 
     Args:
         data: EDAData container. Requires y.
         fig: Matplotlib figure. If None, creates new figure.
         ax: Matplotlib axes. If None, creates new axes.
-        return_rsquared: If True, returns R-squared as third element.
+        return_rsquared: If True, includes R-squared as the third element.
 
     Returns:
-        (fig, ax) or (fig, ax, r_squared) if return_rsquared is True.
+        (fig, ax, r_squared) where r_squared is None if return_rsquared
+        is False.
     """
     fig, ax = get_figure_and_axes(fig, ax)
     _, (_, _, r_value) = sp.stats.probplot(
         data.y, dist="norm", plot=ax, rvalue=True
     )
-    ax.set_ylabel("Ordered Values")
+    ax.set_ylabel(_ORDERED_VALUES)
     ax.set_xlabel("Theoretical Quantiles")
     ax.set_title("Normal Probability Plot")
     fig.tight_layout()
-    if return_rsquared:
-        return fig, ax, r_value**2
-    return fig, ax
+    r_squared = r_value**2 if return_rsquared else None
+    return fig, ax, r_squared
 
 
 def four_plot(
@@ -290,7 +292,7 @@ def weibull_plot(
         "-",
         label=f"Fit with R$^2$={result.rsquared:.3g}",
     )
-    ax.set_xlabel("Ordered Values")
+    ax.set_xlabel(_ORDERED_VALUES)
     ax.set_ylabel("Theoretical Quantiles (Weibull)")
     ax.set_title("Weibull Probability Plot")
     min_percentage = np.floor(
@@ -332,7 +334,7 @@ def probability_plot(
     """
     fig, ax = get_figure_and_axes(fig, ax)
     sp.stats.probplot(data.y, dist=distribution, plot=ax)
-    ax.set_ylabel("Ordered Values")
+    ax.set_ylabel(_ORDERED_VALUES)
     ax.set_xlabel("Theoretical Quantiles")
     ax.set_title(f"{distribution.capitalize()} Probability Plot")
     fig.tight_layout()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -183,7 +183,7 @@ class TestFluentMethods:
         assert isinstance(ax, Axes)
 
     def test_normal_probability_plot(self, univariate_data):
-        fig, ax = univariate_data.normal_probability_plot()
+        fig, ax, _ = univariate_data.normal_probability_plot()
         assert isinstance(fig, Figure)
         assert isinstance(ax, Axes)
 

--- a/tests/test_univariate.py
+++ b/tests/test_univariate.py
@@ -179,30 +179,30 @@ class TestHistogram:
 
 class TestNormalProbabilityPlot:
     def test_returns_figure_and_axes(self, univariate_data):
-        fig, ax = uv.normal_probability_plot(univariate_data)
+        fig, ax, _ = uv.normal_probability_plot(univariate_data)
         assert isinstance(fig, Figure)
         assert isinstance(ax, Axes)
 
     def test_custom_fig_ax(self, univariate_data):
         provided_fig, provided_ax = plt.subplots()
-        fig, ax = uv.normal_probability_plot(
+        fig, ax, _ = uv.normal_probability_plot(
             univariate_data, fig=provided_fig, ax=provided_ax
         )
         assert fig is provided_fig
         assert ax is provided_ax
 
     def test_returns_rsquared_when_requested(self, univariate_data):
-        result = uv.normal_probability_plot(
+        fig, ax, rsq = uv.normal_probability_plot(
             univariate_data, return_rsquared=True
         )
-        assert len(result) == 3
-        _, _, rsq = result
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
         assert isinstance(rsq, float)
         assert 0 <= rsq <= 1
 
-    def test_returns_two_by_default(self, univariate_data):
-        result = uv.normal_probability_plot(univariate_data)
-        assert len(result) == 2
+    def test_rsquared_is_none_by_default(self, univariate_data):
+        _, _, rsq = uv.normal_probability_plot(univariate_data)
+        assert rsq is None
 
 
 # --- four_plot ---


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`onefactor.py`** — Extract `"Factor Level"` string literal to module-level constant `_FACTOR_LEVEL` (was duplicated 3× across `box_plot`, `mean_plot`, `sd_plot`) — fixes SonarCloud S1192
- **`univariate.py`** — Extract `"Ordered Values"` string literal to module-level constant `_ORDERED_VALUES` (was duplicated 3× across `normal_probability_plot`, `weibull_plot`, `probability_plot`) — fixes SonarCloud S1192
- **`univariate.py`** — Refactor `normal_probability_plot` to always return a consistent 3-tuple `(fig, ax, r_squared | None)` instead of varying between a 2-tuple and 3-tuple — fixes SonarCloud S8495
- Update tests in `test_univariate.py` and `test_data.py` to unpack the new 3-tuple signature

## Test plan

- [x] `uv run pytest tests/test_univariate.py tests/test_data.py tests/test_onefactor.py -v` — 110 tests pass
- [x] `uv run ruff check` — no lint errors

https://claude.ai/code/session_01QyNMNvCJcKdksyRRtL7LqN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyNMNvCJcKdksyRRtL7LqN)_