### PR TITLE
feat: Phase 4 — comparative plots (block_plot, youden_plot, star_plot)

### DIFF
--- a/src/drippy/__init__.py
+++ b/src/drippy/__init__.py
@@ -1,6 +1,9 @@
 """drippy — EDA plotting library following NIST/SEMATECH principles."""
 
 import logging
+from drippy.comparative import block_plot
+from drippy.comparative import star_plot
+from drippy.comparative import youden_plot
 from drippy.data import EDAData
 from drippy.multifactor import contour_plot
 from drippy.multifactor import doe_mean_plot
@@ -43,6 +46,7 @@ __all__ = [
     "EDAData",
     "autocorrelation_plot",
     "bihistogram",
+    "block_plot",
     "bootstrap_plot",
     "box_cox_linearity_plot",
     "box_cox_normality_plot",
@@ -70,5 +74,7 @@ __all__ = [
     "sd_plot",
     "six_plot",
     "spectral_plot",
+    "star_plot",
     "weibull_plot",
+    "youden_plot",
 ]

--- a/src/drippy/comparative.py
+++ b/src/drippy/comparative.py
@@ -39,7 +39,7 @@ def block_plot(
     if (
         not data.factors
         or "treatment" not in data.factors
-        or ("block" not in data.factors)
+        or "block" not in data.factors
     ):
         msg = "block_plot requires factors with 'treatment' and 'block' keys"
         raise ValueError(msg)

--- a/src/drippy/comparative.py
+++ b/src/drippy/comparative.py
@@ -140,6 +140,7 @@ def star_plot(
     if not data.factors:
         msg = "star_plot requires factors"
         raise ValueError(msg)
+    # PolarAxes needs projection="polar"; get_figure_and_axes is not used here.
     if fig is None and ax is None:
         fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
     elif fig is not None and ax is None:

--- a/src/drippy/comparative.py
+++ b/src/drippy/comparative.py
@@ -36,8 +36,10 @@ def block_plot(
     Raises:
         ValueError: If factors is None or missing required keys.
     """
-    if not data.factors or "treatment" not in data.factors or (
-        "block" not in data.factors
+    if (
+        not data.factors
+        or "treatment" not in data.factors
+        or ("block" not in data.factors)
     ):
         msg = "block_plot requires factors with 'treatment' and 'block' keys"
         raise ValueError(msg)

--- a/src/drippy/comparative.py
+++ b/src/drippy/comparative.py
@@ -1,0 +1,167 @@
+"""Plotting functions for comparative and multivariate models."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import matplotlib.pyplot as plt
+import numpy as np
+from drippy.utilities import get_figure_and_axes
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from drippy.data import EDAData
+
+_MARKERS = ["o", "s", "^", "D", "v", "P", "*", "X"]
+
+
+def block_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+) -> tuple[Figure, Axes]:
+    """Creates a block plot of y vs treatment, grouped by block.
+
+    Shows treatment effects within each block as connected line segments,
+    one series per block level.
+
+    Args:
+        data: EDAData container. Requires factors with keys
+            ``"treatment"`` and ``"block"``.
+        fig: Matplotlib figure. If None, creates new figure.
+        ax: Matplotlib axes. If None, creates new axes.
+
+    Returns:
+        The figure and axes containing the plot.
+
+    Raises:
+        ValueError: If factors is None or missing required keys.
+    """
+    if not data.factors or "treatment" not in data.factors or (
+        "block" not in data.factors
+    ):
+        msg = "block_plot requires factors with 'treatment' and 'block' keys"
+        raise ValueError(msg)
+    treatment = data.factors["treatment"]
+    block = data.factors["block"]
+    fig, ax = get_figure_and_axes(fig, ax)
+    for i, b in enumerate(np.unique(block)):
+        mask = block == b
+        t_vals = treatment[mask]
+        y_vals = data.y[mask]
+        sort_idx = np.argsort(t_vals)
+        marker = _MARKERS[i % len(_MARKERS)]
+        ax.plot(
+            t_vals[sort_idx],
+            y_vals[sort_idx],
+            marker=marker,
+            linestyle="-",
+            label=str(b),
+        )
+    ax.set_xlabel("Treatment")
+    ax.set_ylabel("Y")
+    ax.set_title("Block Plot")
+    ax.legend(title="Block")
+    fig.tight_layout()
+    return fig, ax
+
+
+def youden_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+    doe: bool = False,
+) -> tuple[Figure, Axes]:
+    """Creates a Youden plot comparing two labs or measurement methods.
+
+    Plots Lab 1 (y) vs Lab 2 (x) with an equality line and median
+    reference lines to reveal bias and lab effects.
+
+    Args:
+        data: EDAData container. Requires x (Lab 2 measurements)
+            and y (Lab 1 measurements).
+        fig: Matplotlib figure. If None, creates new figure.
+        ax: Matplotlib axes. If None, creates new axes.
+        doe: If True, overlays DOE design point markers.
+
+    Returns:
+        The figure and axes containing the plot.
+
+    Raises:
+        ValueError: If x is None.
+    """
+    if data.x is None:
+        msg = "youden_plot requires x"
+        raise ValueError(msg)
+    fig, ax = get_figure_and_axes(fig, ax)
+    ax.scatter(data.x, data.y)
+    lo = min(data.x.min(), data.y.min())
+    hi = max(data.x.max(), data.y.max())
+    ax.plot([lo, hi], [lo, hi], "r--", label="y = x")
+    med_y = np.median(data.y)
+    med_x = np.median(data.x)
+    ax.axhline(med_y, color="gray", linestyle=":", label="Median Lab 1")
+    ax.axvline(med_x, color="gray", linestyle=":", label="Median Lab 2")
+    if doe:
+        ax.scatter(
+            data.x, data.y, marker="x", color="k", zorder=5, label="DOE points"
+        )
+    ax.set_xlabel("Lab 2 (X)")
+    ax.set_ylabel("Lab 1 (Y)")
+    ax.set_title("Youden Plot")
+    ax.legend()
+    fig.tight_layout()
+    return fig, ax
+
+
+def star_plot(
+    data: EDAData,
+    fig: Figure | None = None,
+    ax: Axes | None = None,
+) -> tuple[Figure, Axes]:
+    """Creates a star (radar) plot of multivariate data.
+
+    Each observation is drawn as a polygon on a polar axis, with one
+    spoke per variable. Values are normalized 0-1 per variable.
+
+    Args:
+        data: EDAData container. Requires factors for additional
+            variables beyond y.
+        fig: Matplotlib figure. If None, creates new polar figure.
+        ax: Matplotlib axes (polar). If None, creates new polar axes.
+
+    Returns:
+        The figure and axes containing the plot.
+
+    Raises:
+        ValueError: If factors is None.
+    """
+    if not data.factors:
+        msg = "star_plot requires factors"
+        raise ValueError(msg)
+    if fig is None and ax is None:
+        fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
+    elif fig is not None and ax is None:
+        ax = fig.add_subplot(1, 1, 1, projection="polar")
+    elif fig is None:
+        fig = ax.get_figure()
+    var_names = ["y", *list(data.factors.keys())]
+    factor_cols = [data.factors[k] for k in data.factors]
+    all_vals = np.column_stack([data.y, *factor_cols])
+    col_min = all_vals.min(axis=0)
+    col_max = all_vals.max(axis=0)
+    span = col_max - col_min
+    span[span == 0] = 1.0
+    normed = (all_vals - col_min) / span
+    n_vars = len(var_names)
+    angles = np.linspace(0, 2 * np.pi, n_vars, endpoint=False)
+    closed_angles = np.append(angles, angles[0])
+    for row in normed:
+        closed_vals = np.append(row, row[0])
+        ax.plot(closed_angles, closed_vals)
+        ax.fill(closed_angles, closed_vals, alpha=0.1)
+    ax.set_xticks(angles)
+    ax.set_xticklabels(var_names)
+    ax.set_ylim(0, 1)
+    ax.set_title("Star Plot")
+    fig.tight_layout()
+    return fig, ax

--- a/tests/test_comparative.py
+++ b/tests/test_comparative.py
@@ -1,0 +1,196 @@
+"""Tests for drippy.comparative (Phase 4)."""
+
+from __future__ import annotations
+import matplotlib as mpl
+
+mpl.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+import drippy.comparative as cp
+from drippy.data import EDAData
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def block_data():
+    rng = np.random.default_rng(0)
+    y = rng.standard_normal(24)
+    treatment = np.tile([1, 2, 3, 4], 6)
+    block = np.repeat([1, 2, 3, 4, 5, 6], 4)
+    return EDAData(y=y, factors={"treatment": treatment, "block": block})
+
+
+@pytest.fixture
+def youden_data():
+    rng = np.random.default_rng(1)
+    y = rng.standard_normal(20)
+    x = y + rng.normal(scale=0.1, size=20)
+    return EDAData(y=y, x=x)
+
+
+@pytest.fixture
+def star_data():
+    rng = np.random.default_rng(2)
+    y = rng.standard_normal(5)
+    return EDAData(
+        y=y,
+        factors={
+            "A": rng.standard_normal(5),
+            "B": rng.standard_normal(5),
+            "C": rng.standard_normal(5),
+        },
+    )
+
+
+class TestBlockPlot:
+    def test_returns_figure_and_axes(self, block_data):
+        fig, ax = cp.block_plot(block_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_requires_factors_not_none(self):
+        data = EDAData(y=[1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="treatment"):
+            cp.block_plot(data)
+
+    def test_requires_treatment_key(self):
+        factors = {"block": np.array([1, 1, 2])}
+        data = EDAData(y=[1.0, 2.0, 3.0], factors=factors)
+        with pytest.raises(ValueError, match="treatment"):
+            cp.block_plot(data)
+
+    def test_requires_block_key(self):
+        factors = {"treatment": np.array([1, 2, 3])}
+        data = EDAData(y=[1.0, 2.0, 3.0], factors=factors)
+        with pytest.raises(ValueError, match="block"):
+            cp.block_plot(data)
+
+    def test_custom_fig_ax(self, block_data):
+        fig_in, ax_in = plt.subplots()
+        fig_out, ax_out = cp.block_plot(block_data, fig=fig_in, ax=ax_in)
+        assert fig_out is fig_in
+        assert ax_out is ax_in
+
+    def test_has_labels(self, block_data):
+        _, ax = cp.block_plot(block_data)
+        assert ax.get_xlabel() != ""
+        assert ax.get_ylabel() != ""
+        assert ax.get_title() != ""
+
+    def test_legend_present(self, block_data):
+        _, ax = cp.block_plot(block_data)
+        assert ax.get_legend() is not None
+
+    def test_one_line_per_block(self, block_data):
+        _, ax = cp.block_plot(block_data)
+        n_blocks = len(np.unique(block_data.factors["block"]))
+        assert len(ax.get_lines()) >= n_blocks
+
+
+class TestYoudenPlot:
+    def test_returns_figure_and_axes(self, youden_data):
+        fig, ax = cp.youden_plot(youden_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_requires_x(self):
+        data = EDAData(y=[1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="requires x"):
+            cp.youden_plot(data)
+
+    def test_custom_fig_ax(self, youden_data):
+        fig_in, ax_in = plt.subplots()
+        fig_out, ax_out = cp.youden_plot(youden_data, fig=fig_in, ax=ax_in)
+        assert fig_out is fig_in
+        assert ax_out is ax_in
+
+    def test_has_labels(self, youden_data):
+        _, ax = cp.youden_plot(youden_data)
+        assert ax.get_xlabel() != ""
+        assert ax.get_ylabel() != ""
+        assert ax.get_title() != ""
+
+    def test_equality_line_present(self, youden_data):
+        _, ax = cp.youden_plot(youden_data)
+        assert len(ax.get_lines()) >= 1
+
+    def test_median_lines_present(self, youden_data):
+        _, ax = cp.youden_plot(youden_data)
+        assert len(ax.get_lines()) >= 3
+
+    def test_doe_adds_scatter_collection(self, youden_data):
+        _, ax_no_doe = cp.youden_plot(youden_data)
+        n_base = len(ax_no_doe.collections)
+        plt.close("all")
+        _, ax_doe = cp.youden_plot(youden_data, doe=True)
+        assert len(ax_doe.collections) == n_base + 1
+
+    def test_legend_present(self, youden_data):
+        _, ax = cp.youden_plot(youden_data)
+        assert ax.get_legend() is not None
+
+
+class TestStarPlot:
+    def test_returns_figure_and_axes(self, star_data):
+        fig, ax = cp.star_plot(star_data)
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_requires_factors(self):
+        data = EDAData(y=[1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="requires factors"):
+            cp.star_plot(data)
+
+    def test_custom_fig_ax(self, star_data):
+        fig_in, ax_in = plt.subplots(subplot_kw={"projection": "polar"})
+        fig_out, ax_out = cp.star_plot(star_data, fig=fig_in, ax=ax_in)
+        assert fig_out is fig_in
+        assert ax_out is ax_in
+
+    def test_has_title(self, star_data):
+        _, ax = cp.star_plot(star_data)
+        assert ax.get_title() != ""
+
+    def test_one_polygon_per_observation(self, star_data):
+        _, ax = cp.star_plot(star_data)
+        assert len(ax.get_lines()) == len(star_data.y)
+
+    def test_spoke_labels_match_variables(self, star_data):
+        _, ax = cp.star_plot(star_data)
+        labels = [t.get_text() for t in ax.get_xticklabels()]
+        assert "y" in labels
+        assert "A" in labels
+        assert "B" in labels
+        assert "C" in labels
+
+    def test_single_observation(self):
+        data = EDAData(y=[3.0], factors={"A": np.array([1.0])})
+        fig, ax = cp.star_plot(data)
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+
+class TestFluentMethods:
+    def test_block_plot_fluent(self, block_data):
+        fig, ax = block_data.block_plot()
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_youden_plot_fluent(self, youden_data):
+        fig, ax = youden_data.youden_plot()
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)
+
+    def test_star_plot_fluent(self, star_data):
+        fig, ax = star_data.star_plot()
+        assert isinstance(fig, Figure)
+        assert isinstance(ax, Axes)


### PR DESCRIPTION
## Summary

- Adds `src/drippy/comparative.py` with 3 new NIST EDA plots (Phase 4, the final phase):
  - `block_plot` (NIST 1.3.3.3): treatment vs block effects in a blocking design
  - `youden_plot` (NIST 1.3.3.31): interlab comparison with equality line, median reference lines, and optional `doe` variant
  - `star_plot` (NIST 1.3.3.29): multivariate radar/star chart with per-variable 0–1 normalization
- Adds `tests/test_comparative.py` with 26 tests covering return types, validation, custom fig/ax, visual properties, and fluent method delegation
- Updates `src/drippy/__init__.py` to export the 3 new functions (37 total public names)
- No changes to `data.py` — fluent method stubs were already in place

## Test plan

- [x] `uv run pytest tests/test_comparative.py -v` — 26 new tests pass
- [x] `uv run pytest tests/ -v` — full suite passes (236 tests, 0 failures)
- [x] `uv run ruff check src/drippy/comparative.py tests/test_comparative.py src/drippy/__init__.py` — clean

https://claude.ai/code/session_014yUeoDbS4TxRj7vXyhGyvL

---
_Generated by [Claude Code](https://claude.ai/code/session_014yUeoDbS4TxRj7vXyhGyvL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three new comparative visualizations are available: block plots (treatment/block comparisons), Youden plots (with reference lines and optional DOE markers), and star (radar) plots for multivariate exploration. These are exported on the package top-level for direct import.

* **Tests**
  * Added comprehensive tests covering visuals, labels/legends, error conditions, and fluent plotting methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pjieter/drippy/pull/24)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->