### PR TITLE
fix: switch ReadTheDocs install from Poetry to uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,13 +6,11 @@ build:
     python: "3.12"
   jobs:
     post_install:
-      # Install poetry
-      # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry==2.2
+      # Install uv for dependency management
+      - pip install uv
       # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The ReadTheDocs build was failing because `.readthedocs.yaml` used `poetry install --with docs` to install dependencies
- The project has migrated to `uv` and uses PEP 735 `[dependency-groups]` in `pyproject.toml`, which Poetry does not support
- Replace `pip install poetry==2.2` + `poetry install --with docs` with `pip install uv` + `uv sync --group docs`

## Test plan

- [ ] Trigger a new ReadTheDocs build and verify it completes successfully
- [ ] Confirm docs dependencies (sphinx, sphinx-rtd-theme, sphinx-autoapi, myst-nb, ipykernel) are installed correctly

https://claude.ai/code/session_01SBqLHxV8V4vSaBVtsrg1sL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBqLHxV8V4vSaBVtsrg1sL)_