### PR TITLE
fix: add --active flag to uv sync for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,6 @@ build:
       # Install dependencies with 'docs' dependency group
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs --active
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
## Summary

- After the Poetry→uv migration in #27, the build still failed with `ModuleNotFoundError: No module named 'autoapi'`
- uv 0.11+ ignores `VIRTUAL_ENV` when it doesn't match the project's `.venv` path — packages were installed into `.venv` instead of RTD's managed virtualenv
- The uv warning in the build log was explicit: *"use `--active` to target the active environment instead"*
- Add `--active` so uv installs into the active virtualenv (the one RTD created and runs Sphinx from)

## Test plan

- [ ] Trigger a new ReadTheDocs build and verify it completes successfully with no `ModuleNotFoundError`

https://claude.ai/code/session_01SBqLHxV8V4vSaBVtsrg1sL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBqLHxV8V4vSaBVtsrg1sL)_